### PR TITLE
64-bit seeds

### DIFF
--- a/worker/games.py
+++ b/worker/games.py
@@ -1321,7 +1321,7 @@ def run_games(
     if "start" in task:
         print("Variable task sizes used. Opening offset = {}".format(opening_offset))
     start_game_index = opening_offset + input_total_games
-    run_seed = int(hashlib.sha1(run["_id"].encode("utf-8")).hexdigest(), 16) % (2**30)
+    run_seed = int(hashlib.sha1(run["_id"].encode("utf-8")).hexdigest(), 16) % (2**64)
 
     # Format options according to fastchess syntax.
     def parse_options(s):

--- a/worker/tests/test_worker.py
+++ b/worker/tests/test_worker.py
@@ -71,9 +71,7 @@ class workerTest(unittest.TestCase):
         self.assertTrue(worker.verify_toolchain())
 
     def test_setup_fastchess(self):
-        self.assertTrue(
-            worker.setup_fastchess(Path.cwd(), list(worker.detect_compilers().keys())[0])
-        )
+        self.assertTrue(worker.setup_fastchess(Path.cwd()))
 
 
 if __name__ == "__main__":

--- a/worker/tests/test_worker.py
+++ b/worker/tests/test_worker.py
@@ -71,7 +71,9 @@ class workerTest(unittest.TestCase):
         self.assertTrue(worker.verify_toolchain())
 
     def test_setup_fastchess(self):
-        self.assertTrue(worker.setup_fastchess(Path.cwd()))
+        self.assertTrue(
+            worker.setup_fastchess(Path.cwd(), list(worker.detect_compilers().keys())[0])
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fast-chess supports 64 bit seeds allowing for much larger amount of unique opening book sequences